### PR TITLE
Expand kernel log buffer on VMM and VM

### DIFF
--- a/apps/Arm/vm_qemu_virtio/rpi4/devices.camkes
+++ b/apps/Arm/vm_qemu_virtio/rpi4/devices.camkes
@@ -53,7 +53,7 @@ assembly {
             "initrd_name" : "linux-initrd",
         };
         vm0.tracebuffer_base = 0x08800000;
-        vm0.tracebuffer_size = 0x200000;
+        vm0.tracebuffer_size = 0xA00000;
         vm0.mmios = [
             "0xff846000:0x1000:12"
         ];

--- a/apps/Arm/vm_qemu_virtio/src/trace.c
+++ b/apps/Arm/vm_qemu_virtio/src/trace.c
@@ -133,12 +133,20 @@ void trace_init(vm_t *vm)
         trace_init_shared_mem(vm, "sel4buf_mem", tracebuffer_base, sel4buf_mem_size_bits,
                 kernel_trace_frame, &kernel_trace_vm, &kernel_trace);
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
         for (int i = 0; i < NUM_BUFFER_FRAME; i++){
-            int error = seL4_BenchmarkSetLogBuffer(kernel_trace_frame[i].cptr);
+            seL4_SetMR(0, i);
+            int error = seL4_BenchmarkSetLargeLogBuffer(kernel_trace_frame[i].cptr,seL4_MessageInfo_new(0, 0, 0, 1));
             if (error) {
                 ZF_LOGF("Cannot set kernel log buffer");
             }
         }
+#else 
+        int error = seL4_BenchmarkSetLogBuffer(kernel_trace_frame[0].cptr);
+        if (error) {
+            ZF_LOGF("Cannot set kernel log buffer");
+        }
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
 
     }
 }


### PR DESCRIPTION
- Allocate a set of frame caps for logging.
- Reserve a suitable tracebuffer_size in VM.
- Map the allocated frame caps to VM's virtual memory.