### PR TITLE
Expand kernel log buffer on VMM and VM

### DIFF
--- a/apps/Arm/vm_qemu_virtio/rpi4/devices.camkes
+++ b/apps/Arm/vm_qemu_virtio/rpi4/devices.camkes
@@ -53,7 +53,7 @@ assembly {
             "initrd_name" : "linux-initrd",
         };
         vm0.tracebuffer_base = 0x08800000;
-        vm0.tracebuffer_size = 0x200000;
+        vm0.tracebuffer_size = 0xA00000;
         vm0.mmios = [
             "0xff846000:0x1000:12"
         ];

--- a/apps/Arm/vm_qemu_virtio/src/trace.c
+++ b/apps/Arm/vm_qemu_virtio/src/trace.c
@@ -15,10 +15,15 @@
 extern vka_t _vka;
 extern vspace_t _vspace;
 
-static vka_object_t kernel_trace_frame, __kernel_trace_frame;
+static vka_object_t *kernel_trace_frame, __kernel_trace_frame;
 void *kernel_trace, *__kernel_trace;
 void *kernel_trace_vm, *__kernel_trace_vm;
 
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+static const unsigned int NUM_BUFFER_FRAME = CONFIG_NUM_LOG_BUFFER_FRAME;
+#else
+static const unsigned int NUM_BUFFER_FRAME = 1;
+#endif /* CONFIG_CONFIG_NUM_LOG_BUFFER_FRAME */
 static const char *trace_names[TRACE_POINT_MAX];
 static int trace_names_count;
 
@@ -66,46 +71,51 @@ void trace_init_shared_mem(vm_t *vm, const char *name,
 		const uint64_t mem_addr, const uint64_t mem_size,
 		vka_object_t *local_mem, void **vm_memory, void **vmm_memory)
 {
-    /* virtual address to use on VM side,
-     * otherwise it will allocate @0x10000000
-     * and conflicts with VM's memory
-     */
-    void *vaddr = (void *)mem_addr;
+    /* Create duplicated caps to map VM */
+    seL4_CPtr slot[NUM_BUFFER_FRAME];
+    
+    for (int i = 0; i < NUM_BUFFER_FRAME; i++){
+        /* virtual address to use on VM side,
+         * otherwise it will allocate @0x10000000
+         * and conflicts with VM's memory
+         */
+        void *vaddr = (void *)mem_addr + BIT(mem_size)*i;
 
-    /* Allocate memory  */
-    int error = vka_alloc_frame(&_vka, mem_size, local_mem);
-    if (error) {
-	    ZF_LOGF("%s: failed to allocate pages for kernel log, size: 0x%lx", name, mem_size);
-    }
-    ZF_LOGE("%s: allocated page @0x%lx", name, local_mem->cptr);
+        /* Allocate memory  */
+        int error = vka_alloc_frame(&_vka, mem_size, &local_mem[i]);
+        if (error) {
+	        ZF_LOGF("%s: failed to allocate pages for kernel log, size: 0x%lx", name, mem_size);
+        }
+        ZF_LOGE("%s: allocated page @0x%lx", name, local_mem[i].cptr);
 
-    /* Reserve VM virtual memory mem_size@vaddr */
-    reservation_t reservation =  vspace_reserve_range_at(&vm->mem.vm_vspace, vaddr, BIT(mem_size), seL4_AllRights, true);
-    assert(reservation.res);
-    ZF_LOGE("%s: reserved vaddr: 0x%lx", name, (unsigned long)vaddr);
+        /* Reserve VM virtual memory mem_size@vaddr */
+        reservation_t reservation =  vspace_reserve_range_at(&vm->mem.vm_vspace, vaddr, BIT(mem_size), seL4_AllRights, true);
+        assert(reservation.res);
+        ZF_LOGE("%s: reserved vaddr: 0x%lx", name, (unsigned long)vaddr);
 
-    /* Map page to the VM's vspace */
-    error = vspace_map_pages_at_vaddr(&vm->mem.vm_vspace, &local_mem->cptr, NULL, vaddr, 1, mem_size, reservation);
-    assert(error == seL4_NoError);
-    ZF_LOGE("%s: frame @0x%lx mapped to VM-> @0x%lx", name, local_mem->cptr, (unsigned long)vaddr);
-    *vm_memory = vaddr;
+        /* Map page to the VM's vspace */
+        error = vspace_map_pages_at_vaddr(&vm->mem.vm_vspace, &local_mem[i].cptr, NULL, vaddr, 1, mem_size, reservation);
+        assert(error == seL4_NoError);
+        ZF_LOGE("%s: frame @0x%lx mapped to VM-> @0x%lx", name, local_mem[i].cptr, (unsigned long)vaddr);
+        *vm_memory = vaddr;
 
-    /* Duplicate the cap */
-    seL4_CPtr slot;
-    error = vka_cspace_alloc(&_vka, &slot);
-    assert(!error);
+        
+        error = vka_cspace_alloc(&_vka, &slot[i]);
+        assert(!error);
 
-    error = vka_cnode_copy(local_mem->cptr, slot, seL4_AllRights);
-    assert(error == seL4_NoError);
+        error = vka_cnode_copy(local_mem[i].cptr, slot[i], seL4_AllRights);
+        assert(error == seL4_NoError);
+    } 
 
     /* Maps page to VMM's vspace */
-    *vmm_memory = vspace_map_pages(&_vspace, &slot, NULL, seL4_AllRights, 1, mem_size, true);
+    *vmm_memory = vspace_map_pages(&_vspace, slot, NULL, seL4_AllRights, NUM_BUFFER_FRAME, mem_size, true);
     assert(*vmm_memory);
-    ZF_LOGE("%s: frame @0x%lx mapped to VMM-> @0x%lx\n", name, local_mem->cptr, (unsigned long)*vmm_memory);
+    ZF_LOGE("%s: frame @0x%lx mapped to VMM-> @0x%lx\n", name, local_mem[0].cptr, (unsigned long)*vmm_memory);
 }
 
 void trace_init(vm_t *vm)
 {
+
     if (&ramoops_base && &ramoops_size && ramoops_base && ramoops_size) {
         const uint64_t pstore_mem_size_bits = seL4_LargePageBits;
 
@@ -119,16 +129,25 @@ void trace_init(vm_t *vm)
     if (&tracebuffer_base && &tracebuffer_size && tracebuffer_base && tracebuffer_size) {
         const uint64_t sel4buf_mem_size_bits = seL4_LargePageBits;
 
-        if (tracebuffer_size != BIT(seL4_LargePageBits))
-             ZF_LOGF("For now only 2M (seL4_LargePageBits) size supported. tracebuffer_size: 0x%x", tracebuffer_size);
-
+        kernel_trace_frame = calloc(NUM_BUFFER_FRAME,sizeof(vka_object_t));
         trace_init_shared_mem(vm, "sel4buf_mem", tracebuffer_base, sel4buf_mem_size_bits,
-                &kernel_trace_frame, &kernel_trace_vm, &kernel_trace);
+                kernel_trace_frame, &kernel_trace_vm, &kernel_trace);
 
-        int error = seL4_BenchmarkSetLogBuffer(kernel_trace_frame.cptr);
+#ifdef CONFIG_ENABLE_LOG_BUFFER_EXPANSION
+        for (int i = 0; i < NUM_BUFFER_FRAME; i++){
+            seL4_SetMR(0, i);
+            int error = seL4_BenchmarkSetLargeLogBuffer(kernel_trace_frame[i].cptr,seL4_MessageInfo_new(0, 0, 0, 1));
+            if (error) {
+                ZF_LOGF("Cannot set kernel log buffer");
+            }
+        }
+#else 
+        int error = seL4_BenchmarkSetLogBuffer(kernel_trace_frame[0].cptr);
         if (error) {
             ZF_LOGF("Cannot set kernel log buffer");
         }
+#endif /* CONFIG_ENABLE_LOG_BUFFER_EXPANSION */
+
     }
 }
 


### PR DESCRIPTION
- Allocate a set of frame caps for logging.
- Reserve a suitable tracebuffer_size in VM.
- Map the allocated frame caps to VM's virtual memory with "seL4_BenchmarkSetLargeLogBuffer".