### PR TITLE
Map vpci interrupts to virtual INTx pins

### DIFF
--- a/include/ioreq.h
+++ b/include/ioreq.h
@@ -34,6 +34,7 @@ typedef struct io_proxy {
     rpcmsg_queue_t *rx_queue;
     void (*backend_notify)(struct io_proxy *io_proxy);
     int (*run)(struct io_proxy *io_proxy);
+    uint32_t backend_id;
     uintptr_t data_base;
     size_t data_size;
     uintptr_t ctrl_base;

--- a/templates/seL4VirtIODriverVM.template.c
+++ b/templates/seL4VirtIODriverVM.template.c
@@ -60,6 +60,7 @@ io_proxy_t vm/*? dev.id ?*/_io_proxy = {
     .ctrl_base = /*? dev.ctrl_base ?*/,
     .ctrl_size = /*? dev.ctrl_size ?*/,
     .run = vm/*? dev.id ?*/_io_proxy_run,
+    .backend_id = /*? dev.id ?*/,
     .iobuf_page_get = vm/*? dev.id ?*/_iobuf_page_get,
     .backend_notify = vm/*? dev.id ?*/_backend_notify,
 };


### PR DESCRIPTION
Reserve first 32 interrupts for vPCI devices, and swizzle map the interrupts to virtual INTx interrupt lines.