### PR TITLE
Clean cache before starting guest

### DIFF
--- a/apps/Arm/vm_qemu_virtio/rpi4/devices.camkes
+++ b/apps/Arm/vm_qemu_virtio/rpi4/devices.camkes
@@ -63,6 +63,7 @@ assembly {
             "generate_dtb" : true,
             "provide_dtb" : false,
             "map_one_to_one" : true,
+            "clean_cache" : true,
         };
         vm0.vm_virtio_drivers = [
             VIRTIO_DRIVER_CONFIGURATION_DEF(0, 1)
@@ -150,6 +151,7 @@ assembly {
             "provide_initrd" : false,
             "generate_dtb" : true,
             "provide_dtb" : false,
+            "clean_cache" : true,
         };
         vm1.vm_virtio_devices = [
             VIRTIO_DEVICE_CONFIGURATION_DEF(0, 1)


### PR DESCRIPTION
vm1 in vm_qemu_virtio example suddenly started bailing out with the following error message:

------------------------------------------------------------------- Bad syscall from [vm1]: scno -8627683328 at PC: 0xffffffc008021e54m

main_continued@main.c:1272 Failed to run VM
-------------------------------------------------------------------

Turns out the very early Linux boot code runs with MMU off (in our case, stage-1 translation disabled), checking CurrentEL and storing it to RAM. There is also combination of "dmb sy" + "dc ivac" to make sure cache line is filled from RAM when MMU is enabled and the stored value is read (possible hypervisor running on EL2).

It should be noted when VMM initializes the guest RAM (zeroes out the pages, loads kernel, initrd and device tree), cache lines are populated. On a very rare occasion, on rpi4 these cache lines seem to be cleaned (written to RAM) after the barrier / cache invalidate combination discussed above, overwriting EL1/EL2 check result and leading Linux to believe it is running in EL2 and trying to switch using VHE. At that point Linux uses 'hvc' instruction to call the hypervisor, but this time seL4 is there. And that's when vCPU thread fault handle, the VMM, gets unknown syscall message and you see the error message above.

It seems clean_cache is enabled for NVIDIA's TX1 and TX2, both using a cluster of Cortex-A57 cores (TX2 also has their proprietary Denver cluster, but seL4 does not use that). rpi4's Cortex-A72 is a direct successor to Cortex-A57, so no wonder it needs explicit cache clean also.

The only thing that is still unclear is why do not all platforms need explicit cache clean before starting guest.